### PR TITLE
Add padding on pre to match background position

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -609,7 +609,7 @@ td.gutter pre {
   background-color: #fff;
 }
 .highlight > pre {
-  padding: 0;
+  padding: 10px;
 }
 td.code pre {
   border-width: 0 0 0 2px;


### PR DESCRIPTION
`.highlight > pre` sets `background-position: 0px 10px;` to its background. But it also uses `padding: 0` so the background displayed not properly matched. And the left black border is located too close to the source codes and decreases readabilities. So I added 10 pixels padding on every side.

And, thank you for great articles.

Before
<img width="612" alt="Screen Shot 2019-04-05 at 4 32 05 PM" src="https://user-images.githubusercontent.com/579366/55611498-a7ad4a80-57c0-11e9-9d53-2853677891c6.png">

After
<img width="605" alt="Screen Shot 2019-04-05 at 4 32 25 PM" src="https://user-images.githubusercontent.com/579366/55611499-a7ad4a80-57c0-11e9-8182-4ac5d673b617.png">
